### PR TITLE
UNSDG Regions pulled from APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .Ruserdata
 script_temp
 temp
+
+.venv

--- a/Python/README.md
+++ b/Python/README.md
@@ -1,0 +1,34 @@
+# Python Scripts for Downloading Regional Data
+This repository provides Python scripts to download regional aggregates from APIs or other data sources.  
+We are transitioning to API-based access for faster, more reliable updates. **Automation is preferred over static files.**
+
+## Installation
+### Prerequisites
+- Python 3.8+ (check with `python --version`)
+
+### Steps (Windows)
+1. Create a Virtual Environemnt with the command: python -m venv .venv
+2. Activate the Virtual Environemnt with the command: .venv\Scripts\activate
+3. Install the dependencies with the command: pip install -r requirements.txt
+
+
+## Usage
+Each script in the Python folder downloads a specific regional aggregate.  
+As the project grows, common functionality may be moved into reusable "library" modules.
+
+Steps to run the scripts:
+- Install Python
+- create a virtual environment with the command: python -m venv .venv
+- activate the virtual environment with the command: .venv\Scripts\activate
+- install the requirements: pip install -r requirements.txt
+- Run the script
+
+### unsdg_api_download.py
+This script downloads the the **UNSDG Regional aggregates** from the https://unstats.un.org server.  
+It generates multiple .csv output files, one for each UN-defined hierarchy, such as:
+
+* UNSDG_Land_Locked_Developing_Countries_(LLDC).csv
+* UNSDG_Least_Developed_Countries_(LDC).csv
+
+
+to run the script use the command: python unsdg_api_download.py <output_folder> (e.g. python unsdg_api_download.py c:\unstats_regions)

--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -1,0 +1,2 @@
+pandas==2.3.*
+requests==2.32.*

--- a/Python/unsdg_api_download.py
+++ b/Python/unsdg_api_download.py
@@ -1,0 +1,161 @@
+import requests
+import csv
+import argparse
+import os
+import sys
+
+import pandas as pd
+
+# API endpoint
+url_geo_tree = "https://unstats.un.org/sdgs/UNSDGAPIV5/v1/sdg/GeoArea/Tree"
+headers = {"accept": "application/json"}
+
+# Columns rename
+col_rename_map = {
+    "geoAreaCode": "Region_Code",
+    "geoAreaName": "Region",
+    "child_geoAreaName": "Area",
+    "child_geoAreaCode": "Area_Code_M49",
+    "child_type": "Type",
+}
+
+
+def download_json(url: str, headers: dict) -> list:
+
+    response = requests.get(url, headers=headers)
+
+    # Check for successful response
+    if response.status_code == 200:
+        data = response.json()  # Parse JSON content
+        return data
+    else:
+        print(f"Request failed with status code {response.status_code}")
+    return []
+
+
+def flatten_hierarchy(node, parent=None, results=None):
+
+    if results is None:
+        results = []
+    # Extract current node info
+    current = {
+        "geoAreaCode": node.get("geoAreaCode"),
+        "geoAreaName": node.get("geoAreaName"),
+        "type": node.get("type"),
+    }
+
+    # If there is a parent, record the relationship
+    if parent:
+        results.append(
+            {
+                "parent_geoAreaCode": parent["geoAreaCode"],
+                "parent_geoAreaName": parent["geoAreaName"],
+                "parent_type": parent["type"],
+                "geoAreaCode": current["geoAreaCode"],
+                "geoAreaName": current["geoAreaName"],
+                "type": current["type"],
+            }
+        )
+    else:
+        # For the root, we still include it but parent fields are empty
+        results.append(
+            {
+                "parent_geoAreaCode": "",
+                "parent_geoAreaName": "",
+                "parent_type": "",
+                "geoAreaCode": current["geoAreaCode"],
+                "geoAreaName": current["geoAreaName"],
+                "type": current["type"],
+            }
+        )
+
+        # Recurse for children if present
+    children = node.get("children")
+    if children:
+        for child in children:
+            flatten_hierarchy(child, current, results)
+
+    return results
+
+
+def _get_root_name(root_node):
+    ret = root_node.get("geoAreaName", "")
+    ret = ret.replace(" ", "_")
+    return ret
+
+
+def reshape_to_unicef_format(cl: list) -> list:
+    ret = []
+    # Step 1: Keep the regions
+    regions = [item for item in cl if item["type"] == "Region"]
+    # Step 2: For each region, find its children
+    for region in regions:
+        region_code = region["geoAreaCode"]
+        children = [item for item in cl if item["parent_geoAreaCode"] == region_code]
+
+        for child in children:
+            region_copy = region.copy()
+            # Attach child info
+            region_copy["child_geoAreaCode"] = child["geoAreaCode"]
+            region_copy["child_geoAreaName"] = child["geoAreaName"]
+            region_copy["child_type"] = child["type"]
+            ret.append(region_copy)
+
+    return ret
+
+
+def main(output_folder):
+    try:
+        os.makedirs(output_folder, exist_ok=True)
+        print(f"Output folder is set to: {output_folder}")
+    except Exception as e:
+        print(f"Error creating output folder: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    tree = download_json(url_geo_tree, headers)
+
+    for tree_root_node in tree:
+        flattened = flatten_hierarchy(tree_root_node)
+        # print(flattened)
+
+        unicef_flattened = reshape_to_unicef_format(flattened)
+
+        # col_type = {c: str for c in unicef_flattened[0].keys()}
+        # print(col_type)
+        df = pd.DataFrame(data=unicef_flattened, dtype=str)
+
+        df = df.sort_values(by=["parent_geoAreaCode"])
+        df = df.drop(
+            columns=["type", "parent_type", "parent_geoAreaCode", "parent_geoAreaName"]
+        )
+
+        root_name = _get_root_name(tree_root_node)
+        df["Regional_Grouping"] = root_name
+        df = df.rename(columns=col_rename_map)
+        new_col_order = [
+            "Regional_Grouping",
+            "Region",
+            "Region_Code",
+            "Area",
+            "Area_Code_M49",
+            "Type",
+        ]
+
+        for c in df.columns:
+            assert c in new_col_order, (
+                "Rearranging the column order will drop the column " + c
+            )
+
+        df = df[new_col_order]
+
+        file_name = f"UNSDG_{root_name}.csv"
+        file_path = os.path.join(output_folder, file_name)
+        df.to_csv(file_path, index=False, encoding="utf-8", quoting=csv.QUOTE_MINIMAL)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="UNSDG hierarchies to flat CSV.")
+    parser.add_argument("output_folder", type=str, help="Path to the output folder")
+    args = parser.parse_args()
+
+    main(args.output_folder)

--- a/output/UNSDG/UNSDG_Custom_groupings_of_data_providers.csv
+++ b/output/UNSDG/UNSDG_Custom_groupings_of_data_providers.csv
@@ -1,0 +1,120 @@
+Regional_Grouping,Region,Region_Code,Area,Area_Code_M49,Type
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Latin America,420,Region
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Bay of Bengal,99084,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Red Sea,99083,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Arabian Sea,99082,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Somali Coastal Current,99081,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Agulhas Current,99080,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Benguela Current,99079,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Guinea Current,99078,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Canary Current,99077,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Mediterranean Sea,99076,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Iberian Coastal,99075,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Celtic-Biscay Shelf,99074,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Baltic Sea,99073,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Gulf of Thailand,99085,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: North Sea,99072,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Barents Sea,99070,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Greenland Sea,99069,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Canadian Eastern Arctic - West Greenland,99068,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: North Brazil Shelf,99067,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: East Brazil Shelf,99066,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: South Brazil Shelf,99065,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Patagonian Shelf,99064,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Humboldt Current,99063,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Caribbean Sea,99062,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Pacific Central-American Coastal,99061,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Insular Pacific-Hawaiian,99060,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Labrador - Newfoundland,99059,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Norwegian Sea,99071,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Scotian Shelf,99058,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: South China Sea,99086,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Indonesian Sea,99088,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Central Arctic,99114,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Hudson Bay Complex,99113,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Black Sea,99112,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Antarctica,99111,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Faroe Plateau,99110,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Iceland Shelf and Sea,99109,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Kara Sea,99108,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Laptev Sea,99107,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: East Siberian Sea,99106,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Beaufort Sea,99105,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Northern Bering - Chukchi Seas,99104,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: West Bering Sea,99103,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Sulu-Celebes Sea,99087,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Sea of Okhotsk,99102,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Sea of Japan,99100,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Kuroshio Current,99099,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Yellow Sea,99098,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: East China Sea,99097,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: New Zealand Shelf,99096,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Northwest Australian Shelf,99095,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: West Central Australian Shelf,99094,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: South West Australian Shelf,99093,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Southeast Australian Shelf,99092,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: East Central Australian Shelf,99091,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Northeast Australian Shelf,99090,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: North Australian Shelf,99089,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Oyashio Current,99101,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Aleutian Islands,99115,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Northeast U.S. Continental Shelf,99057,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Gulf of Mexico,99055,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,"FAO Major Fishing Area: Atlantic, Northwest",99023,Major Fishing Areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,"FAO Major Fishing Area: Pacific, Southwest",99022,Major Fishing Areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,"FAO Major Fishing Area: Pacific, Western Central",99021,Major Fishing Areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,"FAO Major Fishing Area: Pacific, Northwest",99020,Major Fishing Areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,"FAO Major Fishing Area: Pacific, Northeast",99019,Major Fishing Areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,"FAO Major Fishing Area: Pacific, Eastern Central",99018,Major Fishing Areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,ODA residual,921,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Regional Centres (FAO),919,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,European Union,97,Region
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,European Union (EU) Institutions,918,Region
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,International Centers (FAO),917,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,WTO Developed Member States,916,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,"FAO Major Fishing Area: Atlantic, Northeast",99024,Major Fishing Areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,WTO Developing Member States,915,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Low and middle income economies (WB),913,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Lower middle economies (WB),912,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Low income economies (WB),911,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Other regions (ILO),907,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,North America (ILO),906,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Middle East (ILO),905,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Middle East and North Africa (ILO),904,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Central and Eastern Europe (ILO),903,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Asia and the Pacific (ILO),902,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Africa (ILO),901,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,World Trade Organization (WTO) Member States,889,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Development Assistance Committee members (DAC),593,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Upper middle economies (WB),914,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Southeast U.S. Continental Shelf,99056,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,"FAO Major Fishing Area: Indian Ocean, Eastern",99025,Major Fishing Areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,"FAO Major Fishing Area: Indian Ocean, Western",99027,Major Fishing Areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Gulf of California,99054,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: California Current,99053,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Gulf of Alaska,99052,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: East Bering Sea,99051,Large Marine Ecosystems
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Unallocated by country,952,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Residual/unallocated ODA: Northern America and Europe,99050,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,"Residual/unallocated ODA: Unspecified, developing countries",99049,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Other Africa (IEA),951,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Other non-OECD Asia,487,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Other non-OECD Oceania,527,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Other non-OECD Americas,636,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Africa not elsewhere specified,577,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,"FAO Major Fishing Area: Atlantic, Southeast",99026,Major Fishing Areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Residual/unallocated ODA: Western Asia and Northern Africa,99040,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Residual/unallocated ODA: Oceania excl. Aus. and N. Zealand,99038,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Residual/unallocated ODA: Latin America and the Caribbean,99037,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Residual/unallocated ODA: Eastern and South-eastern Asia,99036,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Residual/unallocated ODA: Central Asia and Southern Asia,99035,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,World Aviation Bunkers,99034,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,World Marine Bunkers,99033,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Areas not elsewhere specified,896,Country
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,FAO Major Fishing Area: Mediterranean and Black Sea,99032,Major Fishing Areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,"FAO Major Fishing Area: Pacific, Southeast",99031,Major Fishing Areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,"FAO Major Fishing Area: Atlantic, Southwest",99030,Major Fishing Areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,"FAO Major Fishing Area: Atlantic, Eastern Central",99029,Major Fishing Areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,"FAO Major Fishing Area: Atlantic, Western Central",99028,Major Fishing Areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Residual/unallocated ODA: Sub-Saharan Africa,99039,Other areas
+Custom_groupings_of_data_providers,Custom groupings of data providers,922,Large Marine Ecosystem: Canadian High Arctic - North Greenland,99116,Large Marine Ecosystems

--- a/output/UNSDG/UNSDG_Land_Locked_Developing_Countries_(LLDC).csv
+++ b/output/UNSDG/UNSDG_Land_Locked_Developing_Countries_(LLDC).csv
@@ -1,0 +1,37 @@
+Regional_Grouping,Region,Region_Code,Area,Area_Code_M49,Type
+Land_Locked_Developing_Countries_(LLDC),Land Locked Developing Countries (LLDC),432,LLDC Africa,923,Region
+Land_Locked_Developing_Countries_(LLDC),Land Locked Developing Countries (LLDC),432,LLDC Americas,924,Region
+Land_Locked_Developing_Countries_(LLDC),Land Locked Developing Countries (LLDC),432,LLDC Asia,925,Region
+Land_Locked_Developing_Countries_(LLDC),Land Locked Developing Countries (LLDC),432,LLDC Europe,926,Region
+Land_Locked_Developing_Countries_(LLDC),LLDC Americas,924,Paraguay,600,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Asia,925,Afghanistan,4,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Asia,925,Armenia,51,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Asia,925,Azerbaijan,31,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Asia,925,Bhutan,64,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Asia,925,Kazakhstan,398,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Asia,925,Lao People's Democratic Republic,418,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Americas,924,Bolivia (Plurinational State of),68,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Asia,925,Mongolia,496,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Asia,925,Nepal,524,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Asia,925,Tajikistan,762,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Asia,925,Turkmenistan,795,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Asia,925,Uzbekistan,860,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Asia,925,Kyrgyzstan,417,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Africa,923,Zimbabwe,716,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Africa,923,Uganda,800,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Europe,926,North Macedonia,807,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Africa,923,Eswatini,748,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Africa,923,South Sudan,728,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Africa,923,Rwanda,646,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Africa,923,Niger,562,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Africa,923,Mali,466,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Africa,923,Malawi,454,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Africa,923,Lesotho,426,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Africa,923,Ethiopia,231,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Africa,923,Chad,148,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Africa,923,Central African Republic,140,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Africa,923,Burundi,108,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Africa,923,Burkina Faso,854,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Africa,923,Botswana,72,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Africa,923,Zambia,894,Country
+Land_Locked_Developing_Countries_(LLDC),LLDC Europe,926,Republic of Moldova,498,Country

--- a/output/UNSDG/UNSDG_Least_Developed_Countries_(LDC).csv
+++ b/output/UNSDG/UNSDG_Least_Developed_Countries_(LDC).csv
@@ -1,0 +1,49 @@
+Regional_Grouping,Region,Region_Code,Area,Area_Code_M49,Type
+Least_Developed_Countries_(LDC),Least Developed Countries (LDC),199,LDC Africa,927,Region
+Least_Developed_Countries_(LDC),Least Developed Countries (LDC),199,LDC Americas,928,Region
+Least_Developed_Countries_(LDC),Least Developed Countries (LDC),199,LDC Asia,929,Region
+Least_Developed_Countries_(LDC),Least Developed Countries (LDC),199,LDC Oceania,930,Region
+Least_Developed_Countries_(LDC),LDC Africa,927,Senegal,686,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Sierra Leone,694,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Somalia,706,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,South Sudan,728,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Sudan,729,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,United Republic of Tanzania,834,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Togo,768,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Uganda,800,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Zambia,894,Country
+Least_Developed_Countries_(LDC),LDC Asia,929,Afghanistan,4,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Rwanda,646,Country
+Least_Developed_Countries_(LDC),LDC Asia,929,Bangladesh,50,Country
+Least_Developed_Countries_(LDC),LDC Asia,929,Cambodia,116,Country
+Least_Developed_Countries_(LDC),LDC Asia,929,Lao People's Democratic Republic,418,Country
+Least_Developed_Countries_(LDC),LDC Asia,929,Myanmar,104,Country
+Least_Developed_Countries_(LDC),LDC Asia,929,Nepal,524,Country
+Least_Developed_Countries_(LDC),LDC Asia,929,Timor-Leste,626,Country
+Least_Developed_Countries_(LDC),LDC Asia,929,Yemen,887,Country
+Least_Developed_Countries_(LDC),LDC Oceania,930,Kiribati,296,Country
+Least_Developed_Countries_(LDC),LDC Americas,928,Haiti,332,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Niger,562,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Mauritania,478,Country
+Least_Developed_Countries_(LDC),LDC Oceania,930,Solomon Islands,90,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Angola,24,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Benin,204,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Burkina Faso,854,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Burundi,108,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Central African Republic,140,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Chad,148,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Comoros,174,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Democratic Republic of the Congo,180,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Djibouti,262,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Eritrea,232,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Ethiopia,231,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Gambia,270,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Guinea,324,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Guinea-Bissau,624,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Lesotho,426,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Liberia,430,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Madagascar,450,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Malawi,454,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Mali,466,Country
+Least_Developed_Countries_(LDC),LDC Africa,927,Mozambique,508,Country
+Least_Developed_Countries_(LDC),LDC Oceania,930,Tuvalu,798,Country

--- a/output/UNSDG/UNSDG_Small_Island_Developing_States_(SIDS).csv
+++ b/output/UNSDG/UNSDG_Small_Island_Developing_States_(SIDS).csv
@@ -1,0 +1,58 @@
+Regional_Grouping,Region,Region_Code,Area,Area_Code_M49,Type
+Small_Island_Developing_States_(SIDS),Small Island Developing States (SIDS),722,SIDS Africa,931,Region
+Small_Island_Developing_States_(SIDS),Small Island Developing States (SIDS),722,SIDS Americas,932,Region
+Small_Island_Developing_States_(SIDS),Small Island Developing States (SIDS),722,SIDS Asia,933,Region
+Small_Island_Developing_States_(SIDS),Small Island Developing States (SIDS),722,SIDS Oceania,934,Region
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Saint Vincent and the Grenadines,670,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Sint Maarten (Dutch part),534,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,United States Virgin Islands,850,Country
+Small_Island_Developing_States_(SIDS),SIDS Asia,933,Maldives,462,Country
+Small_Island_Developing_States_(SIDS),SIDS Asia,933,Singapore,702,Country
+Small_Island_Developing_States_(SIDS),SIDS Asia,933,Timor-Leste,626,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,American Samoa,16,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,Cook Islands,184,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,Fiji,242,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,French Polynesia,258,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,Guam,316,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,Marshall Islands,584,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Curaçao,531,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,Micronesia (Federated States of),583,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,Nauru,520,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,New Caledonia,540,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,Niue,570,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,Northern Mariana Islands,580,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,Palau,585,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,Papua New Guinea,598,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,Samoa,882,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,Solomon Islands,90,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,Tonga,776,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,Kiribati,296,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,"Bonaire, Sint Eustatius and Saba",535,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Suriname,740,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,Tuvalu,798,Country
+Small_Island_Developing_States_(SIDS),SIDS Africa,931,Cabo Verde,132,Country
+Small_Island_Developing_States_(SIDS),SIDS Africa,931,Comoros,174,Country
+Small_Island_Developing_States_(SIDS),SIDS Africa,931,Guinea-Bissau,624,Country
+Small_Island_Developing_States_(SIDS),SIDS Africa,931,Mauritius,480,Country
+Small_Island_Developing_States_(SIDS),SIDS Africa,931,Sao Tome and Principe,678,Country
+Small_Island_Developing_States_(SIDS),SIDS Africa,931,Seychelles,690,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Anguilla,660,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Antigua and Barbuda,28,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Aruba,533,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Bahamas,44,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Barbados,52,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Trinidad and Tobago,780,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Belize,84,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Cuba,192,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Dominica,212,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Dominican Republic,214,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Grenada,308,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Guyana,328,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Haiti,332,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Jamaica,388,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Montserrat,500,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Puerto Rico,630,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Saint Kitts and Nevis,659,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,Saint Lucia,662,Country
+Small_Island_Developing_States_(SIDS),SIDS Americas,932,British Virgin Islands,92,Country
+Small_Island_Developing_States_(SIDS),SIDS Oceania,934,Vanuatu,548,Country

--- a/output/UNSDG/UNSDG_World_(total)_by_MDG_regions.csv
+++ b/output/UNSDG/UNSDG_World_(total)_by_MDG_regions.csv
@@ -1,0 +1,268 @@
+Regional_Grouping,Region,Region_Code,Area,Area_Code_M49,Type
+World_(total)_by_MDG_regions,World (total) by MDG regions,1,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Region
+World_(total)_by_MDG_regions,World (total) by MDG regions,1,Developing regions,515,Region
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Serbia,688,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,San Marino,674,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Saint Pierre and Miquelon,666,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Russian Federation,643,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Romania,642,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Portugal,620,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Poland,616,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Norway,578,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Norfolk Island,574,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,New Zealand,554,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Netherlands (Kingdom of the),528,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Montenegro,499,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Monaco,492,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Republic of Moldova,498,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Malta,470,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,North Macedonia,807,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Slovakia,703,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Slovenia,705,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Spain,724,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Svalbard and Jan Mayen Islands,744,Country
+World_(total)_by_MDG_regions,Developing regions,515,Oceania (exc. Australia and New Zealand),543,Region
+World_(total)_by_MDG_regions,Developing regions,515,Latin America and the Caribbean,419,Region
+World_(total)_by_MDG_regions,Developing regions,515,South-Eastern Asia,35,Region
+World_(total)_by_MDG_regions,Developing regions,515,Southern Asia,34,Region
+World_(total)_by_MDG_regions,Developing regions,515,Sub-Saharan Africa (inc. Sudan),738,Region
+World_(total)_by_MDG_regions,Developing regions,515,Eastern Asia (excluding Japan),518,Region
+World_(total)_by_MDG_regions,Developing regions,515,"Western Asia (exc. Armenia, Azerbaijan, Cyprus, Israel and Georgia)",485,Region
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Luxembourg,442,Country
+World_(total)_by_MDG_regions,Developing regions,515,Caucasus and Central Asia,135,Region
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Sark,680,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Channel Islands,830,Region
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,United States of America,840,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,United Kingdom of Great Britain and Northern Ireland,826,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Ukraine,804,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Switzerland,756,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Sweden,752,Country
+World_(total)_by_MDG_regions,Developing regions,515,Southern Asia (excluding India),127,Region
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Lithuania,440,Country
+World_(total)_by_MDG_regions,Developing regions,515,Northern Africa (exc. Sudan),746,Region
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Latvia,428,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Czechia,203,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Cyprus,196,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Croatia,191,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Cocos (Keeling) Islands,166,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Christmas Island,162,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Canada,124,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Bulgaria,100,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Denmark,208,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Bosnia and Herzegovina,70,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Belgium,56,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Belarus,112,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Austria,40,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Australia,36,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Albania,8,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Åland Islands,248,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Liechtenstein,438,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Bermuda,60,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Estonia,233,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Andorra,20,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Finland,246,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Faroe Islands,234,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Japan,392,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Israel,376,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Isle of Man,833,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Ireland,372,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Iceland,352,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Hungary,348,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Italy,380,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Heard Island and McDonald Islands,334,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,France,250,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Holy See,336,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Germany,276,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Gibraltar,292,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Jersey,832,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Greece,300,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Greenland,304,Country
+World_(total)_by_MDG_regions,"Developed regions (Europe, Cyprus, Israel, Northern America, Japan, Australia & New Zealand)",514,Guernsey,831,Country
+World_(total)_by_MDG_regions,Central America,13,Panama,591,Country
+World_(total)_by_MDG_regions,Caribbean,29,Curaçao,531,Country
+World_(total)_by_MDG_regions,Caribbean,29,Saint Barthélemy,652,Country
+World_(total)_by_MDG_regions,Caribbean,29,Saint Martin (French Part),663,Country
+World_(total)_by_MDG_regions,Caribbean,29,Saint Vincent and the Grenadines,670,Country
+World_(total)_by_MDG_regions,Caribbean,29,Sint Maarten (Dutch part),534,Country
+World_(total)_by_MDG_regions,Caribbean,29,United States Virgin Islands,850,Country
+World_(total)_by_MDG_regions,Central America,13,Belize,84,Country
+World_(total)_by_MDG_regions,Central America,13,Costa Rica,188,Country
+World_(total)_by_MDG_regions,Central America,13,El Salvador,222,Country
+World_(total)_by_MDG_regions,Central America,13,Honduras,340,Country
+World_(total)_by_MDG_regions,Central America,13,Mexico,484,Country
+World_(total)_by_MDG_regions,Central America,13,Nicaragua,558,Country
+World_(total)_by_MDG_regions,Caribbean,29,"Bonaire, Sint Eustatius and Saba",535,Country
+World_(total)_by_MDG_regions,South America,5,Argentina,32,Country
+World_(total)_by_MDG_regions,Central America,13,Guatemala,320,Country
+World_(total)_by_MDG_regions,Caribbean,29,Martinique,474,Country
+World_(total)_by_MDG_regions,Caribbean,29,Trinidad and Tobago,780,Country
+World_(total)_by_MDG_regions,Caribbean,29,Cayman Islands,136,Country
+World_(total)_by_MDG_regions,South America,5,Bolivia (Plurinational State of),68,Country
+World_(total)_by_MDG_regions,Caribbean,29,Cuba,192,Country
+World_(total)_by_MDG_regions,Caribbean,29,Dominica,212,Country
+World_(total)_by_MDG_regions,Caribbean,29,Dominican Republic,214,Country
+World_(total)_by_MDG_regions,Caribbean,29,Grenada,308,Country
+World_(total)_by_MDG_regions,Caribbean,29,Turks and Caicos Islands,796,Country
+World_(total)_by_MDG_regions,Caribbean,29,Guadeloupe,312,Country
+World_(total)_by_MDG_regions,Caribbean,29,Jamaica,388,Country
+World_(total)_by_MDG_regions,Caribbean,29,Montserrat,500,Country
+World_(total)_by_MDG_regions,Caribbean,29,Netherlands Antilles  [former],530,Country
+World_(total)_by_MDG_regions,Caribbean,29,Puerto Rico,630,Country
+World_(total)_by_MDG_regions,Caribbean,29,Saint Kitts and Nevis,659,Country
+World_(total)_by_MDG_regions,Caribbean,29,Saint Lucia,662,Country
+World_(total)_by_MDG_regions,Caribbean,29,Haiti,332,Country
+World_(total)_by_MDG_regions,South America,5,Bouvet Island,74,Country
+World_(total)_by_MDG_regions,Caribbean,29,Barbados,52,Country
+World_(total)_by_MDG_regions,South America,5,Chile,152,Country
+World_(total)_by_MDG_regions,South America,5,Brazil,76,Country
+World_(total)_by_MDG_regions,Caribbean,29,British Virgin Islands,92,Country
+World_(total)_by_MDG_regions,Caribbean,29,Anguilla,660,Country
+World_(total)_by_MDG_regions,Caribbean,29,Antigua and Barbuda,28,Country
+World_(total)_by_MDG_regions,Caribbean,29,Aruba,533,Country
+World_(total)_by_MDG_regions,South America,5,Venezuela (Bolivarian Republic of),862,Country
+World_(total)_by_MDG_regions,South America,5,Uruguay,858,Country
+World_(total)_by_MDG_regions,South America,5,Suriname,740,Country
+World_(total)_by_MDG_regions,Caribbean,29,Bahamas,44,Country
+World_(total)_by_MDG_regions,South America,5,Peru,604,Country
+World_(total)_by_MDG_regions,South America,5,Paraguay,600,Country
+World_(total)_by_MDG_regions,South America,5,Guyana,328,Country
+World_(total)_by_MDG_regions,South America,5,French Guiana,254,Country
+World_(total)_by_MDG_regions,South America,5,Falkland Islands (Malvinas),238,Country
+World_(total)_by_MDG_regions,South America,5,Ecuador,218,Country
+World_(total)_by_MDG_regions,South America,5,Colombia,170,Country
+World_(total)_by_MDG_regions,South America,5,South Georgia and the South Sandwich Islands,239,Country
+World_(total)_by_MDG_regions,South-Eastern Asia,35,Indonesia,360,Country
+World_(total)_by_MDG_regions,Southern Asia,34,Nepal,524,Country
+World_(total)_by_MDG_regions,Southern Asia,34,Pakistan,586,Country
+World_(total)_by_MDG_regions,Southern Asia,34,Sri Lanka,144,Country
+World_(total)_by_MDG_regions,South-Eastern Asia,35,Brunei Darussalam,96,Country
+World_(total)_by_MDG_regions,South-Eastern Asia,35,Cambodia,116,Country
+World_(total)_by_MDG_regions,South-Eastern Asia,35,Lao People's Democratic Republic,418,Country
+World_(total)_by_MDG_regions,Latin America and the Caribbean,419,Caribbean,29,Region
+World_(total)_by_MDG_regions,South-Eastern Asia,35,Myanmar,104,Country
+World_(total)_by_MDG_regions,South-Eastern Asia,35,Philippines,608,Country
+World_(total)_by_MDG_regions,South-Eastern Asia,35,Singapore,702,Country
+World_(total)_by_MDG_regions,South-Eastern Asia,35,Thailand,764,Country
+World_(total)_by_MDG_regions,South-Eastern Asia,35,Timor-Leste,626,Country
+World_(total)_by_MDG_regions,South-Eastern Asia,35,Viet Nam,704,Country
+World_(total)_by_MDG_regions,Latin America and the Caribbean,419,South America,5,Region
+World_(total)_by_MDG_regions,South-Eastern Asia,35,Malaysia,458,Country
+World_(total)_by_MDG_regions,Latin America and the Caribbean,419,Central America,13,Region
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Pitcairn,612,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Cook Islands,184,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,United States Minor Outlying Islands,581,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Tuvalu,798,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Tonga,776,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Tokelau,772,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Solomon Islands,90,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Samoa,882,Country
+World_(total)_by_MDG_regions,Southern Asia,34,Maldives,462,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Papua New Guinea,598,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Palau,585,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Northern Mariana Islands,580,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Niue,570,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,New Caledonia,540,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Nauru,520,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Micronesia (Federated States of),583,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Marshall Islands,584,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Kiribati,296,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Guam,316,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,French Polynesia,258,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Fiji,242,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,American Samoa,16,Country
+World_(total)_by_MDG_regions,Southern Asia,34,Iran (Islamic Republic of),364,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Liberia,430,Country
+World_(total)_by_MDG_regions,Southern Asia,34,Bhutan,64,Country
+World_(total)_by_MDG_regions,Eastern Asia (excluding Japan),518,"China, Macao Special Administrative Region",446,Country
+World_(total)_by_MDG_regions,Eastern Asia (excluding Japan),518,Eastern Asia (excluding Japan and China),223,Region
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Angola,24,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Benin,204,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Botswana,72,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,British Indian Ocean Territory,86,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Burkina Faso,854,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Burundi,108,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Cameroon,120,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Cabo Verde,132,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Central African Republic,140,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Chad,148,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Comoros,174,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Congo,178,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Democratic Republic of the Congo,180,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Côte d'Ivoire,384,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Djibouti,262,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Equatorial Guinea,226,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Eritrea,232,Country
+World_(total)_by_MDG_regions,Eastern Asia (excluding Japan),518,"China, Hong Kong Special Administrative Region",344,Country
+World_(total)_by_MDG_regions,Southern Asia,34,India,356,Country
+World_(total)_by_MDG_regions,Eastern Asia (excluding Japan),518,China,156,Country
+World_(total)_by_MDG_regions,"Western Asia (exc. Armenia, Azerbaijan, Cyprus, Israel and Georgia)",485,United Arab Emirates,784,Country
+World_(total)_by_MDG_regions,Caucasus and Central Asia,135,Armenia,51,Country
+World_(total)_by_MDG_regions,Caucasus and Central Asia,135,Azerbaijan,31,Country
+World_(total)_by_MDG_regions,Caucasus and Central Asia,135,Georgia,268,Country
+World_(total)_by_MDG_regions,Caucasus and Central Asia,135,Kazakhstan,398,Country
+World_(total)_by_MDG_regions,Caucasus and Central Asia,135,Kyrgyzstan,417,Country
+World_(total)_by_MDG_regions,Caucasus and Central Asia,135,Tajikistan,762,Country
+World_(total)_by_MDG_regions,Caucasus and Central Asia,135,Turkmenistan,795,Country
+World_(total)_by_MDG_regions,Caucasus and Central Asia,135,Uzbekistan,860,Country
+World_(total)_by_MDG_regions,"Western Asia (exc. Armenia, Azerbaijan, Cyprus, Israel and Georgia)",485,Bahrain,48,Country
+World_(total)_by_MDG_regions,"Western Asia (exc. Armenia, Azerbaijan, Cyprus, Israel and Georgia)",485,Iraq,368,Country
+World_(total)_by_MDG_regions,"Western Asia (exc. Armenia, Azerbaijan, Cyprus, Israel and Georgia)",485,Jordan,400,Country
+World_(total)_by_MDG_regions,"Western Asia (exc. Armenia, Azerbaijan, Cyprus, Israel and Georgia)",485,Kuwait,414,Country
+World_(total)_by_MDG_regions,"Western Asia (exc. Armenia, Azerbaijan, Cyprus, Israel and Georgia)",485,Lebanon,422,Country
+World_(total)_by_MDG_regions,"Western Asia (exc. Armenia, Azerbaijan, Cyprus, Israel and Georgia)",485,Oman,512,Country
+World_(total)_by_MDG_regions,"Western Asia (exc. Armenia, Azerbaijan, Cyprus, Israel and Georgia)",485,State of Palestine,275,Country
+World_(total)_by_MDG_regions,"Western Asia (exc. Armenia, Azerbaijan, Cyprus, Israel and Georgia)",485,Qatar,634,Country
+World_(total)_by_MDG_regions,"Western Asia (exc. Armenia, Azerbaijan, Cyprus, Israel and Georgia)",485,Saudi Arabia,682,Country
+World_(total)_by_MDG_regions,"Western Asia (exc. Armenia, Azerbaijan, Cyprus, Israel and Georgia)",485,Syrian Arab Republic,760,Country
+World_(total)_by_MDG_regions,"Western Asia (exc. Armenia, Azerbaijan, Cyprus, Israel and Georgia)",485,Türkiye,792,Country
+World_(total)_by_MDG_regions,"Western Asia (exc. Armenia, Azerbaijan, Cyprus, Israel and Georgia)",485,Yemen,887,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,French Southern Territories,260,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Ethiopia,231,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Gambia,270,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Sierra Leone,694,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Somalia,706,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,South Africa,710,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,South Sudan,728,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Sudan,729,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Eswatini,748,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,United Republic of Tanzania,834,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Togo,768,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Uganda,800,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Seychelles,690,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Zambia,894,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Ascension,655,Country
+World_(total)_by_MDG_regions,Northern Africa (exc. Sudan),746,Algeria,12,Country
+World_(total)_by_MDG_regions,Northern Africa (exc. Sudan),746,Egypt,818,Country
+World_(total)_by_MDG_regions,Northern Africa (exc. Sudan),746,Libya,434,Country
+World_(total)_by_MDG_regions,Northern Africa (exc. Sudan),746,Morocco,504,Country
+World_(total)_by_MDG_regions,Northern Africa (exc. Sudan),746,Tunisia,788,Country
+World_(total)_by_MDG_regions,Northern Africa (exc. Sudan),746,Western Sahara,732,Country
+World_(total)_by_MDG_regions,Southern Asia,34,Afghanistan,4,Country
+World_(total)_by_MDG_regions,Southern Asia,34,Bangladesh,50,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Zimbabwe,716,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Senegal,686,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Sao Tome and Principe,678,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Saint Helena,654,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Ghana,288,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Guinea,324,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Guinea-Bissau,624,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Kenya,404,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Lesotho,426,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Vanuatu,548,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Madagascar,450,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Malawi,454,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Mali,466,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Mauritania,478,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Mauritius,480,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Mayotte,175,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Mozambique,508,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Namibia,516,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Niger,562,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Nigeria,566,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Réunion,638,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Rwanda,646,Country
+World_(total)_by_MDG_regions,Sub-Saharan Africa (inc. Sudan),738,Gabon,266,Country
+World_(total)_by_MDG_regions,Oceania (exc. Australia and New Zealand),543,Wallis and Futuna Islands,876,Country
+World_(total)_by_MDG_regions,Eastern Asia (excluding Japan and China),223,Mongolia,496,Country
+World_(total)_by_MDG_regions,Eastern Asia (excluding Japan and China),223,Republic of Korea,410,Country
+World_(total)_by_MDG_regions,Eastern Asia (excluding Japan and China),223,Democratic People's Republic of Korea,408,Country

--- a/output/UNSDG/UNSDG_World_(total)_by_SDG_regions.csv
+++ b/output/UNSDG/UNSDG_World_(total)_by_SDG_regions.csv
@@ -1,0 +1,295 @@
+Regional_Grouping,Region,Region_Code,Area,Area_Code_M49,Type
+World_(total)_by_SDG_regions,World (total) by SDG regions,1,Sub-Saharan Africa,202,Region
+World_(total)_by_SDG_regions,World (total) by SDG regions,1,Northern Africa and Western Asia,747,Region
+World_(total)_by_SDG_regions,World (total) by SDG regions,1,Central and Southern Asia,62,Region
+World_(total)_by_SDG_regions,World (total) by SDG regions,1,Eastern and South-Eastern Asia,753,Region
+World_(total)_by_SDG_regions,World (total) by SDG regions,1,Latin America and the Caribbean,419,Region
+World_(total)_by_SDG_regions,World (total) by SDG regions,1,Oceania,9,Region
+World_(total)_by_SDG_regions,World (total) by SDG regions,1,Europe and Northern America,513,Region
+World_(total)_by_SDG_regions,Northern Africa and Western Asia,747,Western Asia,145,Region
+World_(total)_by_SDG_regions,Northern Africa and Western Asia,747,Northern Africa,15,Region
+World_(total)_by_SDG_regions,Central and Southern Asia,62,Central Asia,143,Region
+World_(total)_by_SDG_regions,Central and Southern Asia,62,Southern Asia,34,Region
+World_(total)_by_SDG_regions,Eastern and South-Eastern Asia,753,Eastern Asia,30,Region
+World_(total)_by_SDG_regions,Europe and Northern America,513,Northern America,21,Region
+World_(total)_by_SDG_regions,Latin America and the Caribbean,419,Caribbean,29,Region
+World_(total)_by_SDG_regions,Latin America and the Caribbean,419,Central America,13,Region
+World_(total)_by_SDG_regions,Latin America and the Caribbean,419,South America,5,Region
+World_(total)_by_SDG_regions,Eastern and South-Eastern Asia,753,South-Eastern Asia,35,Region
+World_(total)_by_SDG_regions,Oceania,9,Australia and New Zealand,53,Region
+World_(total)_by_SDG_regions,Oceania,9,Melanesia,54,Region
+World_(total)_by_SDG_regions,Sub-Saharan Africa,202,Middle Africa,17,Region
+World_(total)_by_SDG_regions,Sub-Saharan Africa,202,Eastern Africa,14,Region
+World_(total)_by_SDG_regions,Europe and Northern America,513,Europe,150,Region
+World_(total)_by_SDG_regions,Sub-Saharan Africa,202,Western Africa,11,Region
+World_(total)_by_SDG_regions,Sub-Saharan Africa,202,Southern Africa,18,Region
+World_(total)_by_SDG_regions,Oceania,9,Micronesia,57,Region
+World_(total)_by_SDG_regions,Oceania,9,Polynesia,61,Region
+World_(total)_by_SDG_regions,Northern Europe,154,United Kingdom (Scotland),829,Country
+World_(total)_by_SDG_regions,Northern Europe,154,United Kingdom (Northern Ireland),828,Country
+World_(total)_by_SDG_regions,Northern Europe,154,United Kingdom (England and Wales),827,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Andorra,20,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Bosnia and Herzegovina,70,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Croatia,191,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Albania,8,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Gibraltar,292,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Italy,380,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Holy See,336,Country
+World_(total)_by_SDG_regions,Southern Europe,39,North Macedonia,807,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Malta,470,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Montenegro,499,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Portugal,620,Country
+World_(total)_by_SDG_regions,Southern Europe,39,San Marino,674,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Serbia,688,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Slovenia,705,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Kosovo,412,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Serbia and Montenegro [former],891,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Yugoslavia [former],890,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Greece,300,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Sark,680,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Sweden,752,Country
+World_(total)_by_SDG_regions,Northern Europe,154,United Kingdom of Great Britain and Northern Ireland,826,Country
+World_(total)_by_SDG_regions,Eastern Europe,151,Belarus,112,Country
+World_(total)_by_SDG_regions,Eastern Europe,151,Bulgaria,100,Country
+World_(total)_by_SDG_regions,Eastern Europe,151,Czechia,203,Country
+World_(total)_by_SDG_regions,Eastern Europe,151,Hungary,348,Country
+World_(total)_by_SDG_regions,Eastern Europe,151,Republic of Moldova,498,Country
+World_(total)_by_SDG_regions,Eastern Europe,151,Poland,616,Country
+World_(total)_by_SDG_regions,Eastern Europe,151,Romania,642,Country
+World_(total)_by_SDG_regions,Eastern Europe,151,Russian Federation,643,Country
+World_(total)_by_SDG_regions,Eastern Europe,151,Slovakia,703,Country
+World_(total)_by_SDG_regions,Eastern Europe,151,Ukraine,804,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Åland Islands,248,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Denmark,208,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Estonia,233,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Faroe Islands,234,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Finland,246,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Guernsey,831,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Iceland,352,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Ireland,372,Country
+World_(total)_by_SDG_regions,Western Europe,155,Austria,40,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Isle of Man,833,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Jersey,832,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Latvia,428,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Lithuania,440,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Norway,578,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Svalbard and Jan Mayen Islands,744,Country
+World_(total)_by_SDG_regions,Northern Europe,154,Channel Islands,830,Region
+World_(total)_by_SDG_regions,Western Europe,155,Belgium,56,Country
+World_(total)_by_SDG_regions,Southern Europe,39,Spain,724,Country
+World_(total)_by_SDG_regions,Western Europe,155,Germany,276,Country
+World_(total)_by_SDG_regions,Western Europe,155,Liechtenstein,438,Country
+World_(total)_by_SDG_regions,Western Europe,155,Luxembourg,442,Country
+World_(total)_by_SDG_regions,Western Europe,155,Monaco,492,Country
+World_(total)_by_SDG_regions,Western Europe,155,Netherlands (Kingdom of the),528,Country
+World_(total)_by_SDG_regions,Western Europe,155,Switzerland,756,Country
+World_(total)_by_SDG_regions,Western Europe,155,Belgium and Luxembourg,99041,Other areas
+World_(total)_by_SDG_regions,Western Europe,155,France,250,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Seychelles,690,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Somalia,706,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,South Sudan,728,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,United Republic of Tanzania,834,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Uganda,800,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,United Republic of Tanzania (Zanzibar),836,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,United Republic of Tanzania (Mainland),835,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Rwanda,646,Country
+World_(total)_by_SDG_regions,Middle Africa,17,Angola,24,Country
+World_(total)_by_SDG_regions,Middle Africa,17,Cameroon,120,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Zimbabwe,716,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Réunion,638,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Mauritius,480,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Mayotte,175,Country
+World_(total)_by_SDG_regions,Middle Africa,17,Central African Republic,140,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Malawi,454,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Madagascar,450,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Kenya,404,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,French Southern Territories,260,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Ethiopia,231,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Eritrea,232,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Djibouti,262,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Comoros,174,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Burundi,108,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,British Indian Ocean Territory,86,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Mozambique,508,Country
+World_(total)_by_SDG_regions,Middle Africa,17,Chad,148,Country
+World_(total)_by_SDG_regions,Eastern Africa,14,Zambia,894,Country
+World_(total)_by_SDG_regions,Middle Africa,17,Democratic Republic of the Congo,180,Country
+World_(total)_by_SDG_regions,Western Africa,11,Ascension,655,Country
+World_(total)_by_SDG_regions,Middle Africa,17,Congo,178,Country
+World_(total)_by_SDG_regions,Western Africa,11,Sierra Leone,694,Country
+World_(total)_by_SDG_regions,Western Africa,11,Senegal,686,Country
+World_(total)_by_SDG_regions,Western Africa,11,Saint Helena,654,Country
+World_(total)_by_SDG_regions,Western Africa,11,Nigeria,566,Country
+World_(total)_by_SDG_regions,Western Africa,11,Niger,562,Country
+World_(total)_by_SDG_regions,Western Africa,11,Mauritania,478,Country
+World_(total)_by_SDG_regions,Western Africa,11,Mali,466,Country
+World_(total)_by_SDG_regions,Western Africa,11,Liberia,430,Country
+World_(total)_by_SDG_regions,Western Africa,11,Guinea-Bissau,624,Country
+World_(total)_by_SDG_regions,Western Africa,11,Guinea,324,Country
+World_(total)_by_SDG_regions,Western Africa,11,Ghana,288,Country
+World_(total)_by_SDG_regions,Western Africa,11,Togo,768,Country
+World_(total)_by_SDG_regions,Western Africa,11,Côte d'Ivoire,384,Country
+World_(total)_by_SDG_regions,Western Africa,11,Gambia,270,Country
+World_(total)_by_SDG_regions,Middle Africa,17,Gabon,266,Country
+World_(total)_by_SDG_regions,Middle Africa,17,Sao Tome and Principe,678,Country
+World_(total)_by_SDG_regions,Southern Africa,18,Botswana,72,Country
+World_(total)_by_SDG_regions,Southern Africa,18,Lesotho,426,Country
+World_(total)_by_SDG_regions,Middle Africa,17,Equatorial Guinea,226,Country
+World_(total)_by_SDG_regions,Southern Africa,18,South Africa,710,Country
+World_(total)_by_SDG_regions,Southern Africa,18,Eswatini,748,Country
+World_(total)_by_SDG_regions,Western Africa,11,Benin,204,Country
+World_(total)_by_SDG_regions,Western Africa,11,Burkina Faso,854,Country
+World_(total)_by_SDG_regions,Western Africa,11,Cabo Verde,132,Country
+World_(total)_by_SDG_regions,Southern Africa,18,Namibia,516,Country
+World_(total)_by_SDG_regions,South America,5,Bouvet Island,74,Country
+World_(total)_by_SDG_regions,South America,5,Bolivia (Plurinational State of),68,Country
+World_(total)_by_SDG_regions,South America,5,Argentina,32,Country
+World_(total)_by_SDG_regions,Central America,13,Panama,591,Country
+World_(total)_by_SDG_regions,Central America,13,Mexico,484,Country
+World_(total)_by_SDG_regions,Central America,13,Honduras,340,Country
+World_(total)_by_SDG_regions,Central America,13,Guatemala,320,Country
+World_(total)_by_SDG_regions,Central America,13,El Salvador,222,Country
+World_(total)_by_SDG_regions,South America,5,Brazil,76,Country
+World_(total)_by_SDG_regions,Central America,13,Nicaragua,558,Country
+World_(total)_by_SDG_regions,South America,5,Chile,152,Country
+World_(total)_by_SDG_regions,South America,5,Paraguay,600,Country
+World_(total)_by_SDG_regions,South America,5,Ecuador,218,Country
+World_(total)_by_SDG_regions,South America,5,Falkland Islands (Malvinas),238,Country
+World_(total)_by_SDG_regions,South America,5,French Guiana,254,Country
+World_(total)_by_SDG_regions,South America,5,Guyana,328,Country
+World_(total)_by_SDG_regions,South America,5,Peru,604,Country
+World_(total)_by_SDG_regions,South America,5,South Georgia and the South Sandwich Islands,239,Country
+World_(total)_by_SDG_regions,South America,5,Suriname,740,Country
+World_(total)_by_SDG_regions,South America,5,Uruguay,858,Country
+World_(total)_by_SDG_regions,South America,5,Venezuela (Bolivarian Republic of),862,Country
+World_(total)_by_SDG_regions,Central America,13,Costa Rica,188,Country
+World_(total)_by_SDG_regions,South America,5,Colombia,170,Country
+World_(total)_by_SDG_regions,Central America,13,Belize,84,Country
+World_(total)_by_SDG_regions,Caribbean,29,Dominican Republic,214,Country
+World_(total)_by_SDG_regions,Caribbean,29,Sint Maarten (Dutch part),534,Country
+World_(total)_by_SDG_regions,Caribbean,29,United States Virgin Islands,850,Country
+World_(total)_by_SDG_regions,Caribbean,29,Antigua and Barbuda,28,Country
+World_(total)_by_SDG_regions,Caribbean,29,Aruba,533,Country
+World_(total)_by_SDG_regions,Caribbean,29,Bahamas,44,Country
+World_(total)_by_SDG_regions,Caribbean,29,Barbados,52,Country
+World_(total)_by_SDG_regions,Caribbean,29,British Virgin Islands,92,Country
+World_(total)_by_SDG_regions,Caribbean,29,Cayman Islands,136,Country
+World_(total)_by_SDG_regions,Caribbean,29,Cuba,192,Country
+World_(total)_by_SDG_regions,Caribbean,29,Dominica,212,Country
+World_(total)_by_SDG_regions,Caribbean,29,Guadeloupe,312,Country
+World_(total)_by_SDG_regions,Caribbean,29,Haiti,332,Country
+World_(total)_by_SDG_regions,Caribbean,29,Jamaica,388,Country
+World_(total)_by_SDG_regions,Caribbean,29,Grenada,308,Country
+World_(total)_by_SDG_regions,Caribbean,29,Montserrat,500,Country
+World_(total)_by_SDG_regions,Caribbean,29,Saint Vincent and the Grenadines,670,Country
+World_(total)_by_SDG_regions,Caribbean,29,Saint Martin (French Part),663,Country
+World_(total)_by_SDG_regions,Caribbean,29,Saint Barthélemy,652,Country
+World_(total)_by_SDG_regions,Caribbean,29,Martinique,474,Country
+World_(total)_by_SDG_regions,Caribbean,29,"Bonaire, Sint Eustatius and Saba",535,Country
+World_(total)_by_SDG_regions,Caribbean,29,Turks and Caicos Islands,796,Country
+World_(total)_by_SDG_regions,Caribbean,29,Curaçao,531,Country
+World_(total)_by_SDG_regions,Caribbean,29,Saint Lucia,662,Country
+World_(total)_by_SDG_regions,Caribbean,29,Saint Kitts and Nevis,659,Country
+World_(total)_by_SDG_regions,Caribbean,29,Puerto Rico,630,Country
+World_(total)_by_SDG_regions,Caribbean,29,Netherlands Antilles  [former],530,Country
+World_(total)_by_SDG_regions,Caribbean,29,Trinidad and Tobago,780,Country
+World_(total)_by_SDG_regions,Caribbean,29,Anguilla,660,Country
+World_(total)_by_SDG_regions,Northern America,21,Greenland,304,Country
+World_(total)_by_SDG_regions,Europe,150,Eastern Europe,151,Region
+World_(total)_by_SDG_regions,Northern America,21,Canada,124,Country
+World_(total)_by_SDG_regions,Northern America,21,Bermuda,60,Country
+World_(total)_by_SDG_regions,Europe,150,Western Europe,155,Region
+World_(total)_by_SDG_regions,Europe,150,Southern Europe,39,Region
+World_(total)_by_SDG_regions,Europe,150,Northern Europe,154,Region
+World_(total)_by_SDG_regions,Northern America,21,United States of America,840,Country
+World_(total)_by_SDG_regions,Northern America,21,Saint Pierre and Miquelon,666,Country
+World_(total)_by_SDG_regions,Southern Asia,34,Pakistan,586,Country
+World_(total)_by_SDG_regions,Southern Asia,34,Maldives,462,Country
+World_(total)_by_SDG_regions,Southern Asia,34,Iran (Islamic Republic of),364,Country
+World_(total)_by_SDG_regions,Southern Asia,34,India,356,Country
+World_(total)_by_SDG_regions,Southern Asia,34,Bhutan,64,Country
+World_(total)_by_SDG_regions,Southern Asia,34,Bangladesh,50,Country
+World_(total)_by_SDG_regions,Southern Asia,34,Afghanistan,4,Country
+World_(total)_by_SDG_regions,Central Asia,143,Uzbekistan,860,Country
+World_(total)_by_SDG_regions,Central Asia,143,Turkmenistan,795,Country
+World_(total)_by_SDG_regions,Central Asia,143,Tajikistan,762,Country
+World_(total)_by_SDG_regions,Central Asia,143,Kyrgyzstan,417,Country
+World_(total)_by_SDG_regions,Central Asia,143,Kazakhstan,398,Country
+World_(total)_by_SDG_regions,Southern Asia,34,Nepal,524,Country
+World_(total)_by_SDG_regions,Southern Asia,34,Sri Lanka,144,Country
+World_(total)_by_SDG_regions,Western Asia,145,Iraq,368,Country
+World_(total)_by_SDG_regions,Northern Africa,15,Algeria,12,Country
+World_(total)_by_SDG_regions,Northern Africa,15,Egypt,818,Country
+World_(total)_by_SDG_regions,Northern Africa,15,Libya,434,Country
+World_(total)_by_SDG_regions,Northern Africa,15,Morocco,504,Country
+World_(total)_by_SDG_regions,Northern Africa,15,Sudan,729,Country
+World_(total)_by_SDG_regions,Northern Africa,15,Tunisia,788,Country
+World_(total)_by_SDG_regions,Northern Africa,15,Western Sahara,732,Country
+World_(total)_by_SDG_regions,Northern Africa,15,Sudan [former],736,Country
+World_(total)_by_SDG_regions,Western Asia,145,Armenia,51,Country
+World_(total)_by_SDG_regions,Western Asia,145,Azerbaijan,31,Country
+World_(total)_by_SDG_regions,Western Asia,145,Bahrain,48,Country
+World_(total)_by_SDG_regions,Western Asia,145,Iraq (Kurdistan Region),370,Country
+World_(total)_by_SDG_regions,Western Asia,145,Iraq (Central Iraq),369,Country
+World_(total)_by_SDG_regions,Western Asia,145,Yemen,887,Country
+World_(total)_by_SDG_regions,Western Asia,145,United Arab Emirates,784,Country
+World_(total)_by_SDG_regions,Western Asia,145,Türkiye,792,Country
+World_(total)_by_SDG_regions,Western Asia,145,Syrian Arab Republic,760,Country
+World_(total)_by_SDG_regions,Western Asia,145,Saudi Arabia,682,Country
+World_(total)_by_SDG_regions,Western Asia,145,Qatar,634,Country
+World_(total)_by_SDG_regions,Western Asia,145,Cyprus,196,Country
+World_(total)_by_SDG_regions,Western Asia,145,Oman,512,Country
+World_(total)_by_SDG_regions,Western Asia,145,Lebanon,422,Country
+World_(total)_by_SDG_regions,Western Asia,145,Kuwait,414,Country
+World_(total)_by_SDG_regions,Western Asia,145,Jordan,400,Country
+World_(total)_by_SDG_regions,Western Asia,145,Israel,376,Country
+World_(total)_by_SDG_regions,Western Asia,145,Georgia,268,Country
+World_(total)_by_SDG_regions,Western Asia,145,State of Palestine,275,Country
+World_(total)_by_SDG_regions,South-Eastern Asia,35,Thailand,764,Country
+World_(total)_by_SDG_regions,Eastern Asia,30,"China, Hong Kong Special Administrative Region",344,Country
+World_(total)_by_SDG_regions,Eastern Asia,30,China,156,Country
+World_(total)_by_SDG_regions,South-Eastern Asia,35,Viet Nam,704,Country
+World_(total)_by_SDG_regions,South-Eastern Asia,35,Timor-Leste,626,Country
+World_(total)_by_SDG_regions,South-Eastern Asia,35,Philippines,608,Country
+World_(total)_by_SDG_regions,South-Eastern Asia,35,Myanmar,104,Country
+World_(total)_by_SDG_regions,South-Eastern Asia,35,Malaysia,458,Country
+World_(total)_by_SDG_regions,South-Eastern Asia,35,Lao People's Democratic Republic,418,Country
+World_(total)_by_SDG_regions,South-Eastern Asia,35,Indonesia,360,Country
+World_(total)_by_SDG_regions,South-Eastern Asia,35,Singapore,702,Country
+World_(total)_by_SDG_regions,South-Eastern Asia,35,Brunei Darussalam,96,Country
+World_(total)_by_SDG_regions,Eastern Asia,30,Other non-specified areas in Eastern Asia,158,Country
+World_(total)_by_SDG_regions,Eastern Asia,30,Mongolia,496,Country
+World_(total)_by_SDG_regions,Eastern Asia,30,Republic of Korea,410,Country
+World_(total)_by_SDG_regions,Eastern Asia,30,Democratic People's Republic of Korea,408,Country
+World_(total)_by_SDG_regions,Eastern Asia,30,Japan,392,Country
+World_(total)_by_SDG_regions,South-Eastern Asia,35,Cambodia,116,Country
+World_(total)_by_SDG_regions,Eastern Asia,30,"China, Macao Special Administrative Region",446,Country
+World_(total)_by_SDG_regions,Polynesia,61,Samoa,882,Country
+World_(total)_by_SDG_regions,Polynesia,61,Pitcairn,612,Country
+World_(total)_by_SDG_regions,Polynesia,61,Niue,570,Country
+World_(total)_by_SDG_regions,Polynesia,61,French Polynesia,258,Country
+World_(total)_by_SDG_regions,Polynesia,61,Cook Islands,184,Country
+World_(total)_by_SDG_regions,Micronesia,57,United States Minor Outlying Islands,581,Country
+World_(total)_by_SDG_regions,Polynesia,61,American Samoa,16,Country
+World_(total)_by_SDG_regions,Micronesia,57,Palau,585,Country
+World_(total)_by_SDG_regions,Melanesia,54,New Caledonia,540,Country
+World_(total)_by_SDG_regions,Melanesia,54,Fiji,242,Country
+World_(total)_by_SDG_regions,Polynesia,61,Tokelau,772,Country
+World_(total)_by_SDG_regions,Micronesia,57,Northern Mariana Islands,580,Country
+World_(total)_by_SDG_regions,Polynesia,61,Tonga,776,Country
+World_(total)_by_SDG_regions,Micronesia,57,Marshall Islands,584,Country
+World_(total)_by_SDG_regions,Polynesia,61,Wallis and Futuna Islands,876,Country
+World_(total)_by_SDG_regions,Australia and New Zealand,53,Australia,36,Country
+World_(total)_by_SDG_regions,Australia and New Zealand,53,Christmas Island,162,Country
+World_(total)_by_SDG_regions,Australia and New Zealand,53,Cocos (Keeling) Islands,166,Country
+World_(total)_by_SDG_regions,Australia and New Zealand,53,Heard Island and McDonald Islands,334,Country
+World_(total)_by_SDG_regions,Australia and New Zealand,53,New Zealand,554,Country
+World_(total)_by_SDG_regions,Australia and New Zealand,53,Norfolk Island,574,Country
+World_(total)_by_SDG_regions,Micronesia,57,Kiribati,296,Country
+World_(total)_by_SDG_regions,Micronesia,57,Guam,316,Country
+World_(total)_by_SDG_regions,Melanesia,54,Vanuatu,548,Country
+World_(total)_by_SDG_regions,Melanesia,54,Solomon Islands,90,Country
+World_(total)_by_SDG_regions,Melanesia,54,Papua New Guinea,598,Country
+World_(total)_by_SDG_regions,Micronesia,57,Micronesia (Federated States of),583,Country
+World_(total)_by_SDG_regions,Polynesia,61,Tuvalu,798,Country
+World_(total)_by_SDG_regions,Micronesia,57,Nauru,520,Country

--- a/output/UNSDG/UNSDG_World_(total)_by_continental_regions.csv
+++ b/output/UNSDG/UNSDG_World_(total)_by_continental_regions.csv
@@ -1,0 +1,295 @@
+Regional_Grouping,Region,Region_Code,Area,Area_Code_M49,Type
+World_(total)_by_continental_regions,World (total) by continental regions,1,Antarctica,10,Country
+World_(total)_by_continental_regions,World (total) by continental regions,1,Africa,2,Region
+World_(total)_by_continental_regions,World (total) by continental regions,1,Americas,19,Region
+World_(total)_by_continental_regions,World (total) by continental regions,1,Asia,142,Region
+World_(total)_by_continental_regions,World (total) by continental regions,1,Oceania,9,Region
+World_(total)_by_continental_regions,World (total) by continental regions,1,Europe,150,Region
+World_(total)_by_continental_regions,Asia,142,Western Asia,145,Region
+World_(total)_by_continental_regions,Asia,142,Central Asia,143,Region
+World_(total)_by_continental_regions,Asia,142,Southern Asia,34,Region
+World_(total)_by_continental_regions,Asia,142,Eastern Asia,30,Region
+World_(total)_by_continental_regions,Asia,142,South-Eastern Asia,35,Region
+World_(total)_by_continental_regions,Americas,19,Northern America,21,Region
+World_(total)_by_continental_regions,Oceania,9,Melanesia,54,Region
+World_(total)_by_continental_regions,Oceania,9,Micronesia,57,Region
+World_(total)_by_continental_regions,Americas,19,Latin America and the Caribbean,419,Region
+World_(total)_by_continental_regions,Oceania,9,Australia and New Zealand,53,Region
+World_(total)_by_continental_regions,Europe,150,Eastern Europe,151,Region
+World_(total)_by_continental_regions,Europe,150,Northern Europe,154,Region
+World_(total)_by_continental_regions,Europe,150,Southern Europe,39,Region
+World_(total)_by_continental_regions,Oceania,9,Polynesia,61,Region
+World_(total)_by_continental_regions,Africa,2,Northern Africa,15,Region
+World_(total)_by_continental_regions,Africa,2,Sub-Saharan Africa,202,Region
+World_(total)_by_continental_regions,Europe,150,Western Europe,155,Region
+World_(total)_by_continental_regions,Central Asia,143,Kyrgyzstan,417,Country
+World_(total)_by_continental_regions,Central Asia,143,Kazakhstan,398,Country
+World_(total)_by_continental_regions,Western Asia,145,Iraq (Kurdistan Region),370,Country
+World_(total)_by_continental_regions,Western Asia,145,Iraq (Central Iraq),369,Country
+World_(total)_by_continental_regions,Western Asia,145,Yemen,887,Country
+World_(total)_by_continental_regions,Western Asia,145,United Arab Emirates,784,Country
+World_(total)_by_continental_regions,Western Asia,145,Türkiye,792,Country
+World_(total)_by_continental_regions,Western Asia,145,Syrian Arab Republic,760,Country
+World_(total)_by_continental_regions,Western Asia,145,Saudi Arabia,682,Country
+World_(total)_by_continental_regions,Western Asia,145,Qatar,634,Country
+World_(total)_by_continental_regions,Western Asia,145,Oman,512,Country
+World_(total)_by_continental_regions,Central Asia,143,Tajikistan,762,Country
+World_(total)_by_continental_regions,Western Asia,145,Kuwait,414,Country
+World_(total)_by_continental_regions,Western Asia,145,Jordan,400,Country
+World_(total)_by_continental_regions,Western Asia,145,Israel,376,Country
+World_(total)_by_continental_regions,Western Asia,145,Iraq,368,Country
+World_(total)_by_continental_regions,Western Asia,145,Georgia,268,Country
+World_(total)_by_continental_regions,Western Asia,145,Cyprus,196,Country
+World_(total)_by_continental_regions,Western Asia,145,Azerbaijan,31,Country
+World_(total)_by_continental_regions,Western Asia,145,Armenia,51,Country
+World_(total)_by_continental_regions,Western Asia,145,State of Palestine,275,Country
+World_(total)_by_continental_regions,Western Asia,145,Lebanon,422,Country
+World_(total)_by_continental_regions,Central Asia,143,Uzbekistan,860,Country
+World_(total)_by_continental_regions,Southern Asia,34,Afghanistan,4,Country
+World_(total)_by_continental_regions,South-Eastern Asia,35,Viet Nam,704,Country
+World_(total)_by_continental_regions,South-Eastern Asia,35,Timor-Leste,626,Country
+World_(total)_by_continental_regions,South-Eastern Asia,35,Thailand,764,Country
+World_(total)_by_continental_regions,South-Eastern Asia,35,Singapore,702,Country
+World_(total)_by_continental_regions,South-Eastern Asia,35,Philippines,608,Country
+World_(total)_by_continental_regions,South-Eastern Asia,35,Myanmar,104,Country
+World_(total)_by_continental_regions,South-Eastern Asia,35,Malaysia,458,Country
+World_(total)_by_continental_regions,South-Eastern Asia,35,Lao People's Democratic Republic,418,Country
+World_(total)_by_continental_regions,South-Eastern Asia,35,Indonesia,360,Country
+World_(total)_by_continental_regions,South-Eastern Asia,35,Cambodia,116,Country
+World_(total)_by_continental_regions,South-Eastern Asia,35,Brunei Darussalam,96,Country
+World_(total)_by_continental_regions,Eastern Asia,30,Other non-specified areas in Eastern Asia,158,Country
+World_(total)_by_continental_regions,Central Asia,143,Turkmenistan,795,Country
+World_(total)_by_continental_regions,Eastern Asia,30,Mongolia,496,Country
+World_(total)_by_continental_regions,Eastern Asia,30,Democratic People's Republic of Korea,408,Country
+World_(total)_by_continental_regions,Eastern Asia,30,Japan,392,Country
+World_(total)_by_continental_regions,Eastern Asia,30,"China, Macao Special Administrative Region",446,Country
+World_(total)_by_continental_regions,Eastern Asia,30,"China, Hong Kong Special Administrative Region",344,Country
+World_(total)_by_continental_regions,Eastern Asia,30,China,156,Country
+World_(total)_by_continental_regions,Southern Asia,34,Sri Lanka,144,Country
+World_(total)_by_continental_regions,Southern Asia,34,Pakistan,586,Country
+World_(total)_by_continental_regions,Southern Asia,34,Maldives,462,Country
+World_(total)_by_continental_regions,Southern Asia,34,Iran (Islamic Republic of),364,Country
+World_(total)_by_continental_regions,Southern Asia,34,India,356,Country
+World_(total)_by_continental_regions,Southern Asia,34,Bhutan,64,Country
+World_(total)_by_continental_regions,Southern Asia,34,Bangladesh,50,Country
+World_(total)_by_continental_regions,Eastern Asia,30,Republic of Korea,410,Country
+World_(total)_by_continental_regions,Southern Asia,34,Nepal,524,Country
+World_(total)_by_continental_regions,Western Asia,145,Bahrain,48,Country
+World_(total)_by_continental_regions,Western Europe,155,Belgium and Luxembourg,99041,Other areas
+World_(total)_by_continental_regions,Northern Europe,154,Sark,680,Country
+World_(total)_by_continental_regions,Northern Europe,154,Channel Islands,830,Region
+World_(total)_by_continental_regions,Northern Europe,154,Sweden,752,Country
+World_(total)_by_continental_regions,Northern Europe,154,Svalbard and Jan Mayen Islands,744,Country
+World_(total)_by_continental_regions,Northern Europe,154,Norway,578,Country
+World_(total)_by_continental_regions,Northern Europe,154,Lithuania,440,Country
+World_(total)_by_continental_regions,Northern Europe,154,Latvia,428,Country
+World_(total)_by_continental_regions,Northern Europe,154,Jersey,832,Country
+World_(total)_by_continental_regions,Northern Europe,154,Isle of Man,833,Country
+World_(total)_by_continental_regions,Northern Europe,154,Ireland,372,Country
+World_(total)_by_continental_regions,Northern Europe,154,Iceland,352,Country
+World_(total)_by_continental_regions,Northern Europe,154,Guernsey,831,Country
+World_(total)_by_continental_regions,Northern Europe,154,Finland,246,Country
+World_(total)_by_continental_regions,Northern Europe,154,United Kingdom (England and Wales),827,Country
+World_(total)_by_continental_regions,Northern Europe,154,Faroe Islands,234,Country
+World_(total)_by_continental_regions,Northern Europe,154,Denmark,208,Country
+World_(total)_by_continental_regions,Northern Europe,154,Åland Islands,248,Country
+World_(total)_by_continental_regions,Eastern Europe,151,Ukraine,804,Country
+World_(total)_by_continental_regions,Eastern Europe,151,Slovakia,703,Country
+World_(total)_by_continental_regions,Eastern Europe,151,Russian Federation,643,Country
+World_(total)_by_continental_regions,Eastern Europe,151,Romania,642,Country
+World_(total)_by_continental_regions,Eastern Europe,151,Poland,616,Country
+World_(total)_by_continental_regions,Eastern Europe,151,Republic of Moldova,498,Country
+World_(total)_by_continental_regions,Eastern Europe,151,Hungary,348,Country
+World_(total)_by_continental_regions,Eastern Europe,151,Czechia,203,Country
+World_(total)_by_continental_regions,Eastern Europe,151,Bulgaria,100,Country
+World_(total)_by_continental_regions,Eastern Europe,151,Belarus,112,Country
+World_(total)_by_continental_regions,Western Europe,155,Switzerland,756,Country
+World_(total)_by_continental_regions,Northern Europe,154,Estonia,233,Country
+World_(total)_by_continental_regions,Northern Europe,154,United Kingdom (Northern Ireland),828,Country
+World_(total)_by_continental_regions,Northern Europe,154,United Kingdom of Great Britain and Northern Ireland,826,Country
+World_(total)_by_continental_regions,Southern Europe,39,Albania,8,Country
+World_(total)_by_continental_regions,Western Europe,155,Netherlands (Kingdom of the),528,Country
+World_(total)_by_continental_regions,Western Europe,155,Monaco,492,Country
+World_(total)_by_continental_regions,Western Europe,155,Luxembourg,442,Country
+World_(total)_by_continental_regions,Western Europe,155,Liechtenstein,438,Country
+World_(total)_by_continental_regions,Western Europe,155,Germany,276,Country
+World_(total)_by_continental_regions,Western Europe,155,France,250,Country
+World_(total)_by_continental_regions,Western Europe,155,Belgium,56,Country
+World_(total)_by_continental_regions,Northern Europe,154,United Kingdom (Scotland),829,Country
+World_(total)_by_continental_regions,Southern Europe,39,Yugoslavia [former],890,Country
+World_(total)_by_continental_regions,Southern Europe,39,Serbia and Montenegro [former],891,Country
+World_(total)_by_continental_regions,Southern Europe,39,Kosovo,412,Country
+World_(total)_by_continental_regions,Southern Europe,39,Spain,724,Country
+World_(total)_by_continental_regions,Southern Europe,39,Slovenia,705,Country
+World_(total)_by_continental_regions,Western Europe,155,Austria,40,Country
+World_(total)_by_continental_regions,Southern Europe,39,San Marino,674,Country
+World_(total)_by_continental_regions,Southern Europe,39,Portugal,620,Country
+World_(total)_by_continental_regions,Southern Europe,39,Montenegro,499,Country
+World_(total)_by_continental_regions,Southern Europe,39,Malta,470,Country
+World_(total)_by_continental_regions,Southern Europe,39,North Macedonia,807,Country
+World_(total)_by_continental_regions,Southern Europe,39,Italy,380,Country
+World_(total)_by_continental_regions,Southern Europe,39,Holy See,336,Country
+World_(total)_by_continental_regions,Southern Europe,39,Greece,300,Country
+World_(total)_by_continental_regions,Southern Europe,39,Gibraltar,292,Country
+World_(total)_by_continental_regions,Southern Europe,39,Andorra,20,Country
+World_(total)_by_continental_regions,Southern Europe,39,Croatia,191,Country
+World_(total)_by_continental_regions,Southern Europe,39,Serbia,688,Country
+World_(total)_by_continental_regions,Southern Europe,39,Bosnia and Herzegovina,70,Country
+World_(total)_by_continental_regions,Latin America and the Caribbean,419,Caribbean,29,Region
+World_(total)_by_continental_regions,Latin America and the Caribbean,419,Central America,13,Region
+World_(total)_by_continental_regions,Latin America and the Caribbean,419,South America,5,Region
+World_(total)_by_continental_regions,Northern America,21,Canada,124,Country
+World_(total)_by_continental_regions,Northern America,21,Saint Pierre and Miquelon,666,Country
+World_(total)_by_continental_regions,Northern America,21,Greenland,304,Country
+World_(total)_by_continental_regions,Northern America,21,Bermuda,60,Country
+World_(total)_by_continental_regions,Northern America,21,United States of America,840,Country
+World_(total)_by_continental_regions,Sub-Saharan Africa,202,Eastern Africa,14,Region
+World_(total)_by_continental_regions,Sub-Saharan Africa,202,Middle Africa,17,Region
+World_(total)_by_continental_regions,Sub-Saharan Africa,202,Southern Africa,18,Region
+World_(total)_by_continental_regions,Sub-Saharan Africa,202,Western Africa,11,Region
+World_(total)_by_continental_regions,Northern Africa,15,Sudan [former],736,Country
+World_(total)_by_continental_regions,Northern Africa,15,Western Sahara,732,Country
+World_(total)_by_continental_regions,Northern Africa,15,Tunisia,788,Country
+World_(total)_by_continental_regions,Northern Africa,15,Sudan,729,Country
+World_(total)_by_continental_regions,Northern Africa,15,Morocco,504,Country
+World_(total)_by_continental_regions,Northern Africa,15,Libya,434,Country
+World_(total)_by_continental_regions,Northern Africa,15,Egypt,818,Country
+World_(total)_by_continental_regions,Northern Africa,15,Algeria,12,Country
+World_(total)_by_continental_regions,Western Africa,11,Nigeria,566,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Malawi,454,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Mauritius,480,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Mayotte,175,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Mozambique,508,Country
+World_(total)_by_continental_regions,Western Africa,11,Senegal,686,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Rwanda,646,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Seychelles,690,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Madagascar,450,Country
+World_(total)_by_continental_regions,Eastern Africa,14,South Sudan,728,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Réunion,638,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Kenya,404,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Eritrea,232,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Ethiopia,231,Country
+World_(total)_by_continental_regions,Eastern Africa,14,United Republic of Tanzania,834,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Djibouti,262,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Comoros,174,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Burundi,108,Country
+World_(total)_by_continental_regions,Eastern Africa,14,British Indian Ocean Territory,86,Country
+World_(total)_by_continental_regions,Western Africa,11,Saint Helena,654,Country
+World_(total)_by_continental_regions,Western Africa,11,Sierra Leone,694,Country
+World_(total)_by_continental_regions,Western Africa,11,Togo,768,Country
+World_(total)_by_continental_regions,Western Africa,11,Ascension,655,Country
+World_(total)_by_continental_regions,Eastern Africa,14,French Southern Territories,260,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Uganda,800,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Somalia,706,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Zimbabwe,716,Country
+World_(total)_by_continental_regions,Western Africa,11,Niger,562,Country
+World_(total)_by_continental_regions,Eastern Africa,14,Zambia,894,Country
+World_(total)_by_continental_regions,Western Africa,11,Mali,466,Country
+World_(total)_by_continental_regions,Western Africa,11,Liberia,430,Country
+World_(total)_by_continental_regions,Western Africa,11,Guinea-Bissau,624,Country
+World_(total)_by_continental_regions,Western Africa,11,Guinea,324,Country
+World_(total)_by_continental_regions,Western Africa,11,Ghana,288,Country
+World_(total)_by_continental_regions,Western Africa,11,Gambia,270,Country
+World_(total)_by_continental_regions,Western Africa,11,Côte d'Ivoire,384,Country
+World_(total)_by_continental_regions,Western Africa,11,Cabo Verde,132,Country
+World_(total)_by_continental_regions,Western Africa,11,Burkina Faso,854,Country
+World_(total)_by_continental_regions,Western Africa,11,Benin,204,Country
+World_(total)_by_continental_regions,Southern Africa,18,Eswatini,748,Country
+World_(total)_by_continental_regions,Southern Africa,18,South Africa,710,Country
+World_(total)_by_continental_regions,Western Africa,11,Mauritania,478,Country
+World_(total)_by_continental_regions,Southern Africa,18,Lesotho,426,Country
+World_(total)_by_continental_regions,Southern Africa,18,Botswana,72,Country
+World_(total)_by_continental_regions,Middle Africa,17,Sao Tome and Principe,678,Country
+World_(total)_by_continental_regions,Eastern Africa,14,United Republic of Tanzania (Mainland),835,Country
+World_(total)_by_continental_regions,Middle Africa,17,Gabon,266,Country
+World_(total)_by_continental_regions,Southern Africa,18,Namibia,516,Country
+World_(total)_by_continental_regions,Middle Africa,17,Equatorial Guinea,226,Country
+World_(total)_by_continental_regions,Middle Africa,17,Democratic Republic of the Congo,180,Country
+World_(total)_by_continental_regions,Middle Africa,17,Congo,178,Country
+World_(total)_by_continental_regions,Middle Africa,17,Chad,148,Country
+World_(total)_by_continental_regions,Middle Africa,17,Central African Republic,140,Country
+World_(total)_by_continental_regions,Middle Africa,17,Cameroon,120,Country
+World_(total)_by_continental_regions,Middle Africa,17,Angola,24,Country
+World_(total)_by_continental_regions,Eastern Africa,14,United Republic of Tanzania (Zanzibar),836,Country
+World_(total)_by_continental_regions,Caribbean,29,Saint Martin (French Part),663,Country
+World_(total)_by_continental_regions,Caribbean,29,Saint Vincent and the Grenadines,670,Country
+World_(total)_by_continental_regions,Caribbean,29,United States Virgin Islands,850,Country
+World_(total)_by_continental_regions,Caribbean,29,Saint Barthélemy,652,Country
+World_(total)_by_continental_regions,Central America,13,Belize,84,Country
+World_(total)_by_continental_regions,Central America,13,Costa Rica,188,Country
+World_(total)_by_continental_regions,Central America,13,El Salvador,222,Country
+World_(total)_by_continental_regions,Central America,13,Guatemala,320,Country
+World_(total)_by_continental_regions,Central America,13,Honduras,340,Country
+World_(total)_by_continental_regions,Central America,13,Mexico,484,Country
+World_(total)_by_continental_regions,Central America,13,Nicaragua,558,Country
+World_(total)_by_continental_regions,Central America,13,Panama,591,Country
+World_(total)_by_continental_regions,Caribbean,29,Sint Maarten (Dutch part),534,Country
+World_(total)_by_continental_regions,Caribbean,29,Curaçao,531,Country
+World_(total)_by_continental_regions,Caribbean,29,Turks and Caicos Islands,796,Country
+World_(total)_by_continental_regions,South America,5,Argentina,32,Country
+World_(total)_by_continental_regions,Caribbean,29,Anguilla,660,Country
+World_(total)_by_continental_regions,Caribbean,29,Antigua and Barbuda,28,Country
+World_(total)_by_continental_regions,Caribbean,29,Aruba,533,Country
+World_(total)_by_continental_regions,Caribbean,29,Bahamas,44,Country
+World_(total)_by_continental_regions,Caribbean,29,Barbados,52,Country
+World_(total)_by_continental_regions,Caribbean,29,British Virgin Islands,92,Country
+World_(total)_by_continental_regions,Caribbean,29,Cayman Islands,136,Country
+World_(total)_by_continental_regions,Caribbean,29,Cuba,192,Country
+World_(total)_by_continental_regions,Caribbean,29,Dominica,212,Country
+World_(total)_by_continental_regions,Caribbean,29,Dominican Republic,214,Country
+World_(total)_by_continental_regions,Caribbean,29,Grenada,308,Country
+World_(total)_by_continental_regions,Caribbean,29,Guadeloupe,312,Country
+World_(total)_by_continental_regions,Caribbean,29,Haiti,332,Country
+World_(total)_by_continental_regions,Caribbean,29,Jamaica,388,Country
+World_(total)_by_continental_regions,Caribbean,29,Martinique,474,Country
+World_(total)_by_continental_regions,Caribbean,29,Montserrat,500,Country
+World_(total)_by_continental_regions,Caribbean,29,Netherlands Antilles  [former],530,Country
+World_(total)_by_continental_regions,Caribbean,29,Puerto Rico,630,Country
+World_(total)_by_continental_regions,Caribbean,29,Saint Kitts and Nevis,659,Country
+World_(total)_by_continental_regions,Caribbean,29,Saint Lucia,662,Country
+World_(total)_by_continental_regions,Caribbean,29,Trinidad and Tobago,780,Country
+World_(total)_by_continental_regions,Caribbean,29,"Bonaire, Sint Eustatius and Saba",535,Country
+World_(total)_by_continental_regions,South America,5,Bolivia (Plurinational State of),68,Country
+World_(total)_by_continental_regions,South America,5,French Guiana,254,Country
+World_(total)_by_continental_regions,South America,5,Brazil,76,Country
+World_(total)_by_continental_regions,South America,5,Bouvet Island,74,Country
+World_(total)_by_continental_regions,South America,5,Venezuela (Bolivarian Republic of),862,Country
+World_(total)_by_continental_regions,South America,5,Uruguay,858,Country
+World_(total)_by_continental_regions,South America,5,Suriname,740,Country
+World_(total)_by_continental_regions,South America,5,Peru,604,Country
+World_(total)_by_continental_regions,South America,5,South Georgia and the South Sandwich Islands,239,Country
+World_(total)_by_continental_regions,South America,5,Guyana,328,Country
+World_(total)_by_continental_regions,South America,5,Falkland Islands (Malvinas),238,Country
+World_(total)_by_continental_regions,South America,5,Ecuador,218,Country
+World_(total)_by_continental_regions,South America,5,Colombia,170,Country
+World_(total)_by_continental_regions,South America,5,Chile,152,Country
+World_(total)_by_continental_regions,South America,5,Paraguay,600,Country
+World_(total)_by_continental_regions,Micronesia,57,Marshall Islands,584,Country
+World_(total)_by_continental_regions,Micronesia,57,Northern Mariana Islands,580,Country
+World_(total)_by_continental_regions,Micronesia,57,Nauru,520,Country
+World_(total)_by_continental_regions,Micronesia,57,Micronesia (Federated States of),583,Country
+World_(total)_by_continental_regions,Micronesia,57,Kiribati,296,Country
+World_(total)_by_continental_regions,Melanesia,54,Fiji,242,Country
+World_(total)_by_continental_regions,Melanesia,54,Vanuatu,548,Country
+World_(total)_by_continental_regions,Melanesia,54,Solomon Islands,90,Country
+World_(total)_by_continental_regions,Melanesia,54,Papua New Guinea,598,Country
+World_(total)_by_continental_regions,Melanesia,54,New Caledonia,540,Country
+World_(total)_by_continental_regions,Micronesia,57,Palau,585,Country
+World_(total)_by_continental_regions,Micronesia,57,Guam,316,Country
+World_(total)_by_continental_regions,Micronesia,57,United States Minor Outlying Islands,581,Country
+World_(total)_by_continental_regions,Polynesia,61,Tokelau,772,Country
+World_(total)_by_continental_regions,Polynesia,61,Cook Islands,184,Country
+World_(total)_by_continental_regions,Polynesia,61,French Polynesia,258,Country
+World_(total)_by_continental_regions,Polynesia,61,Niue,570,Country
+World_(total)_by_continental_regions,Polynesia,61,Pitcairn,612,Country
+World_(total)_by_continental_regions,Polynesia,61,Samoa,882,Country
+World_(total)_by_continental_regions,Polynesia,61,Tuvalu,798,Country
+World_(total)_by_continental_regions,Polynesia,61,Wallis and Futuna Islands,876,Country
+World_(total)_by_continental_regions,Australia and New Zealand,53,Australia,36,Country
+World_(total)_by_continental_regions,Australia and New Zealand,53,Christmas Island,162,Country
+World_(total)_by_continental_regions,Australia and New Zealand,53,Cocos (Keeling) Islands,166,Country
+World_(total)_by_continental_regions,Australia and New Zealand,53,Heard Island and McDonald Islands,334,Country
+World_(total)_by_continental_regions,Australia and New Zealand,53,New Zealand,554,Country
+World_(total)_by_continental_regions,Australia and New Zealand,53,Norfolk Island,574,Country
+World_(total)_by_continental_regions,Polynesia,61,American Samoa,16,Country
+World_(total)_by_continental_regions,Polynesia,61,Tonga,776,Country


### PR DESCRIPTION
New Python code folder added

UNSDG Regions pulled from the APIs:
https://unstats.un.org/sdgs/UNSDGAPIV5/v1/sdg/GeoArea/Tree

All the Regional aggregates pulled from the API endpoint saved to output/UNSDG/

Need to confirm:
- Do we need a different output format, it can be refined?
- We will probably need a mapping table (maintained separately) between M49 and ISO3
- We can create libraries and subfolders in the Python as needed in the future